### PR TITLE
Speed up git clones by cloning with depth 1

### DIFF
--- a/package/pkg-download.mk
+++ b/package/pkg-download.mk
@@ -67,7 +67,7 @@ domainseparator=$(if $(1),$(1),/)
 define DOWNLOAD_GIT
 	test -e $(DL_DIR)/$($(PKG)_SOURCE) || \
 	(pushd $(DL_DIR) > /dev/null && \
-	$(GIT) clone --bare $($(PKG)_SITE) $($(PKG)_BASE_NAME) && \
+	$(GIT) clone --bare --depth=1 --single-branch -b $($(PKG)_DL_VERSION) $($(PKG)_SITE) $($(PKG)_BASE_NAME) && \
 	pushd $($(PKG)_BASE_NAME) > /dev/null && \
 	$(GIT) archive --format=tar --prefix=$($(PKG)_BASE_NAME)/ $($(PKG)_DL_VERSION) | \
 		gzip -c > $(DL_DIR)/$($(PKG)_SOURCE) && \


### PR DESCRIPTION
There's a lot of larger git repositories we clone, like ADCS and sometimes linux, so only cloning the latest commit from the repository instead of everything is a nice performance improvement.